### PR TITLE
update repo name to terraform-distributed-minio

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,16 +2,16 @@
   Thx for your interest! We're so glad you're here. 
 
 ### Important Resources
-  - bugs: [https://github.com/packet-labs/terraform-packet-distributed-minio/issues](https://github.com/packet-labs/terraform-packet-distributed-minio/issues)
+  - bugs: [https://github.com/packet-labs/terraform-distributed-minio/issues](https://github.com/packet-labs/terraform-distributed-minio/issues)
 
 ### Code of Conduct
-Available via [https://github.com/packet-labs/terraform-packet-distributed-minio/blob/master/CODE_OF_CONDUCT.md](https://github.com/packet-labs/terraform-packet-distributed-minio/blob/master/CODE_OF_CONDUCT.md)
+Available via [https://github.com/packet-labs/terraform-distributed-minio/blob/master/CODE_OF_CONDUCT.md](https://github.com/packet-labs/terraform-distributed-minio/blob/master/CODE_OF_CONDUCT.md)
 
 ### Environment Details
-[https://github.com/packet-labs/terraform-packet-distributed-minio/blob/master/MANIFEST.md](https://github.com/packet-labs/terraform-packet-distributed-minio/blob/master/MANIFEST.md)
+[https://github.com/packet-labs/terraform-distributed-minio/blob/master/MANIFEST.md](https://github.com/packet-labs/terraform-distributed-minio/blob/master/MANIFEST.md)
 
 ### How to Submit Change Requests
-Please submit change requests and / or features via [Issues](https://github.com/packet-labs/terraform-packet-distributed-minio/issues). There's no guarantee it'll be changed, but you never know until you try. I'll try to add comments as soon as possible, though.
+Please submit change requests and / or features via [Issues](https://github.com/packet-labs/terraform-distributed-minio/issues). There's no guarantee it'll be changed, but you never know until you try. I'll try to add comments as soon as possible, though.
 
 ### How to Report a Bug
-Bugs are problems in code, in the functionality of an application or in its UI design; you can submit them through [Issues](https://github.com/packet-labs/terraform-packet-distributed-minio/issues) as well.
+Bugs are problems in code, in the functionality of an application or in its UI design; you can submit them through [Issues](https://github.com/packet-labs/terraform-distributed-minio/issues) as well.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository is [Maintained](https://github.com/packethost/standards/blob/mas
 
 If you require support, please email [support@equinixmetal.com](support@equinixmetal.com), visit the Equinix Metal IRC channel (#equinixmetal on freenode), subscribe to the [Equinix Metal Community Slack](https://equinixmetal.slack.com/) channel or post an issue within this repository.
 
-[Contributions](https://github.com/packet-labs/terraform-packet-distributed-minio/blob/master/CONTRIBUTING.md) are welcome to help extend this work!
+[Contributions](https://github.com/packet-labs/terraform-distributed-minio/blob/master/CONTRIBUTING.md) are welcome to help extend this work!
 
 # Minio Distributed on Equinix Metal with Terraform
 Minio Distributed on Equinix Metal with Terraform is a [Terraform](http://terraform.io) template that will deploy [Minio](http://min.io) distributed on [Equinix Metal](https://metal.equinix.com/) baremetal. MinIO is a high performance object storage server compatible with Amazon S3. Minio is a great option for Equinix Metal users that want to have easily accessible S3 compatible object storage as Equinix Metal offers instance types with storage options including SATA SSDs, NVMe SSDs, and high capacity SATA HDDs.
@@ -20,7 +20,7 @@ This repository currently supports Terraform v0.13 or higher.
 To download this project, run the following command:
 
 ```bash
-git clone https://github.com/packet-labs/terraform-packet-distributed-minio.git
+git clone https://github.com/packet-labs/terraform-distributed-minio.git
 ```
 
 ## Initialize Terraform

--- a/manifest.md
+++ b/manifest.md
@@ -6,7 +6,7 @@
 
 ## Name
 
-Terraform Packet Distributed MinIO
+Terraform Distributed MinIO
 
 ## Repository Version
 
@@ -18,4 +18,4 @@ en
 
 ## Description
 
-packet-distributed-minio is a Terraform template that will deploy Minio distributed on Packet baremetal. MinIO is a high performance object storage server compatible with Amazon S3. Minio is a great option for Packet users that want to have easily accessible S3 compatible object storage as Packet offers instance types with storage options including SATA SSDs, NVMe SSDs, and high capacity SATA HDDs.
+terraform-distributed-minio is a Terraform template that will deploy Minio distributed on Packet baremetal. MinIO is a high performance object storage server compatible with Amazon S3. Minio is a great option for Packet users that want to have easily accessible S3 compatible object storage as Packet offers instance types with storage options including SATA SSDs, NVMe SSDs, and high capacity SATA HDDs.


### PR DESCRIPTION
Fixes #16 

Once this is in, we will rename the repository github.com/packet-labs/terraform-distributed-minio 

There is one external link to this repository in docs; I will open a PR there and link to it here.